### PR TITLE
新增本地网页转PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ build
 *.pyd
 __pycache__/
 *.pyc
+**/__pycache__/


### PR DESCRIPTION
新增本地网页转PDF
` 

    def select_local_html_files(self):
        files, _ = QFileDialog.getOpenFileNames(self, "选择本地网页文件", "", "HTML文件 (*.html *.htm);;All Files (*)")
        if files:
            self.local_html_files = files
            # 清除布局中的所有控件
            for i in reversed(range(self.layout.count())):
                widget = self.layout.itemAt(i).widget()
                if widget is not None:
                    widget.deleteLater()

            # 添加本地文件按钮
            for file_path in self.local_html_files:
                label = QPushButton()
                label.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
                label.setMaximumWidth(250)
                font_metrics = QFontMetrics(self.label_output_dir.font())
                file_name = os.path.basename(file_path)
                # 使用 elidedText 根据按钮宽度生成省略文字
                elided_text = font_metrics.elidedText(file_name, Qt.ElideRight, 240)
                label.setText(elided_text)
                label.setToolTip(file_path)
                label.clicked.connect(
                    lambda checked, path=file_path: QDesktopServices.openUrl(QUrl.fromLocalFile(path))
                )
                self.layout.addWidget(label)
`